### PR TITLE
Allign checkbox and label on FF & Webkit.

### DIFF
--- a/app/assets/stylesheets/_layout.css.scss
+++ b/app/assets/stylesheets/_layout.css.scss
@@ -31,7 +31,7 @@ body {
   }
 
   input[type="checkbox"] {
-    height: 40px;
+    margin-top: 14px;
   }
 
   .postfix, .prefix {

--- a/app/views/coursewareable/sessions/new.html.haml
+++ b/app/views/coursewareable/sessions/new.html.haml
@@ -18,7 +18,7 @@
 
     .row
       .seven.offset-by-three.columns.end
-        = check_box_tag(:remember_me, nil, false, :class => 'left marginless-top')
+        = check_box_tag(:remember_me, nil, false, :class => 'left')
         = label_tag(:remember_me, _('Remember me on this computer'), :class => 'smaller')
 
     .actions


### PR DESCRIPTION
Should fix this.

![courseware1](https://f.cloud.github.com/assets/530000/168880/36009330-7a0c-11e2-9b30-6dad6d7aaaae.png)
