### PR TITLE
do not show menu when create a classroom

### DIFF
--- a/app/views/layouts/coursewareable/application.html.haml
+++ b/app/views/layouts/coursewareable/application.html.haml
@@ -32,7 +32,7 @@
         %h2
           = yield(:title)
 
-    - unless @classroom.nil?
+    - unless @classroom.nil? || @classroom.new_record?
       %nav#classroom-menu
         = render('shared/classroom_menu')
 

--- a/spec/requests/coursewareable/classrooms_spec.rb
+++ b/spec/requests/coursewareable/classrooms_spec.rb
@@ -44,4 +44,19 @@ describe 'Classrooms' do
     page.should have_content(ann_txt)
   end
 
+  context 'menu' do
+    let(:user) { Fabricate(:confirmed_user) }
+
+    it 'can see menu if is member of classroom' do
+      sign_in_with(classroom.owner.email)
+      visit dashboard_classroom_url(:subdomain => classroom.slug)
+      page.should have_css('#classroom-menu')
+    end
+
+    it 'can not see menu if want to create a classroom' do
+      sign_in_with(user.email)
+      visit start_classroom_path
+      page.should_not have_css('#classroom-menu')
+    end
+  end
 end


### PR DESCRIPTION
![screenshot from 2013-06-28 14 50 50](https://f.cloud.github.com/assets/1835042/730058/5f9adf44-e248-11e2-94aa-a90ae9b58357.png)
I resolved it earlier, but I commited on stripe branch. So, I moved it here.
